### PR TITLE
timestamp를 sms발송시점에 생성하도록 변경

### DIFF
--- a/src/ncp_client.ts
+++ b/src/ncp_client.ts
@@ -20,6 +20,11 @@ export type sendSMSReturnType = {
   status: number;
 };
 
+export type prepareSignatureReturnType = {
+  timestamp: string;
+  signature: string;
+};
+
 export class NCPClient {
   private phoneNumber: string;
   private serviceId: string;
@@ -28,8 +33,6 @@ export class NCPClient {
 
   private url: string;
   private method: string;
-  private signature: string;
-  private timestamp: string;
 
   /**
    *
@@ -50,24 +53,7 @@ export class NCPClient {
     this.secretKey = secretKey;
     this.accessKey = accessKey;
     this.url = `https://sens.apigw.ntruss.com/sms/v2/services/${this.serviceId}/messages`;
-    this.timestamp = Date.now().toString();
     this.method = 'POST';
-
-    const space = ' ';
-    const newLine = '\n';
-    const message = [];
-    const hmac = crypto.createHmac('sha256', this.secretKey);
-    const url2 = `/sms/v2/services/${this.serviceId}/messages`;
-
-    message.push(this.method);
-    message.push(space);
-    message.push(url2);
-    message.push(newLine);
-    message.push(this.timestamp);
-    message.push(newLine);
-    message.push(this.accessKey);
-
-    this.signature = hmac.update(message.join('')).digest('base64');
   }
 
   /**
@@ -87,14 +73,15 @@ export class NCPClient {
     countryCode = '82'
   }: sendSMSType): Promise<sendSMSReturnType> {
     try {
+      const {timestamp, signature} = this.prepareSignature()
       const response = await axios({
         method: 'POST',
         url: this.url,
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
           'x-ncp-iam-access-key': this.accessKey,
-          'x-ncp-apigw-timestamp': this.timestamp,
-          'x-ncp-apigw-signature-v2': this.signature,
+          'x-ncp-apigw-timestamp': timestamp,
+          'x-ncp-apigw-signature-v2': signature,
         },
         data: {
           type: 'SMS',
@@ -130,5 +117,33 @@ export class NCPClient {
         status: error.response.status || 500,
       };
     }
+  }
+
+  /**
+   *
+   * API 시그니처를 생성하는 함수
+   *
+   * @returns timestamp(string), signature(string)
+   */
+  private prepareSignature(): prepareSignatureReturnType {
+    const space = ' ';
+    const newLine = '\n';
+    const message = [];
+    const hmac = crypto.createHmac('sha256', this.secretKey);
+    const url2 = `/sms/v2/services/${this.serviceId}/messages`;
+    const timestamp = Date.now().toString();
+
+    message.push(this.method);
+    message.push(space);
+    message.push(url2);
+    message.push(newLine);
+    message.push(timestamp);
+    message.push(newLine);
+    message.push(this.accessKey);
+
+    return {
+      timestamp,
+      signature: hmac.update(message.join('')).digest('base64')
+    };
   }
 }


### PR DESCRIPTION
이슈 #2 해결용

prepareSignature를 함수로 따로 분리하여 sms 전송전에 호출하도록 변경했습니다.

그렇게 깔끔하게 코딩하는편은 아니어서 한번 검토부탁드립니다 :)

테스트는 통과했습니다
![image](https://user-images.githubusercontent.com/8064923/98883677-ea252600-24d1-11eb-9de5-8218bbe58593.png)
